### PR TITLE
DI-2677: Fix decoding of city

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,8 +3,6 @@
 ### 0.8.0j (Unreleased)
 - [#1](https://github.com/jampp/pydruid/pull/1) Harden streamed query reliability
 
-
-
 ### 0.7.0j (2021/08/13 12:12 +00:00)
 
 NOTE: This release is restoring support for Python 2.7

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 ## Change Log
 
 ### 0.8.0j (Unreleased)
-- [#1](https://github.com/jampp/pydruid/pull/1) Harden streamed query reliability
+- [#1](https://github.com/jampp/pydruid/pull/5) Harden streamed query reliability
 
 ### 0.7.0j (2021/08/13 12:12 +00:00)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,11 @@
 ## Change Log
 
-### 0.7.0j (Unreleased)
+### 0.8.0j (Unreleased)
+- [#1](https://github.com/jampp/pydruid/pull/1) Harden streamed query reliability
+
+
+
+### 0.7.0j (2021/08/13 12:12 +00:00)
 
 NOTE: This release is restoring support for Python 2.7
 NOTE: This release is removing support for Druid < 0.13.0

--- a/pydruid/db/api.py
+++ b/pydruid/db/api.py
@@ -373,7 +373,7 @@ class Cursor(object):
 
         # Druid will stream the data in chunks of 8k bytes
         # setting `chunk_size` to `None` makes it use the server size
-        lines = r.iter_lines(chunk_size=None, decode_unicode=True)
+        lines = r.iter_lines(chunk_size=None, decode_unicode=False)
 
         field_names = ujson_loads(next(lines))
         Row = namedtuple("Row", field_names, rename=True)

--- a/setup.py
+++ b/setup.py
@@ -16,7 +16,7 @@ with io.open("README.md", encoding="utf-8") as f:
 
 setup(
     name="pydruid",
-    version="0.7.0j",
+    version="0.8.0j",
     author="Druid Developers",
     author_email="druid-development@googlegroups.com",
     packages=find_packages(),


### PR DESCRIPTION
If we dont decode_unicode when spliting the lines, 

the city called "Ø§ÙÙØ±Ø"§Ø±Ø©"
is still in one row, and can be rendered correctly
If not, the double quote breaks

And you say, Wtf, why is that a city name.
Im with you, no clue. certainly sees like something japanese and broken, but this is the python default serialization, i did nothing of that kind.