### PR TITLE
Fix package version not compliant with PEP440

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -16,7 +16,7 @@ with io.open("README.md", encoding="utf-8") as f:
 
 setup(
     name="pydruid",
-    version="0.9.0j",
+    version="0.9.0+j",
     author="Druid Developers",
     author_email="druid-development@googlegroups.com",
     packages=find_packages(),

--- a/tox.ini
+++ b/tox.ini
@@ -25,6 +25,7 @@ commands =
     flake8 pydruid setup.py tests
 deps =
     flake8==3.9.1
+    importlib-metadata<5.0.0
 
 [tox]
 envlist =


### PR DESCRIPTION
With current versions of pip the following is raised when trying to install the package:

```
WARNING: Built wheel for pydruid is invalid: Metadata 1.2 mandates PEP 440 version, but '0.9.0j' is not
DEPRECATION: pydruid was installed using the legacy 'setup.py install' method, because a wheel could not be built for it. pip 23.1 will enforce this behaviour change.
```
